### PR TITLE
Adding Ubuntu 23.04 Lunar support

### DIFF
--- a/check_compute_drivers.sh
+++ b/check_compute_drivers.sh
@@ -9,7 +9,7 @@ NC='\033[0m' # No Color
 os_name="$(awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '"' | tr '[:upper:]' '[:lower:]')"
 os_version="$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release | tr -d '"')"
 
-ubuntu_version_list=(20.04 22.04)
+ubuntu_version_list=(20.04 22.04 23.04)
 ubuntu_runtime_drivers=(
   "intel-level-zero-gpu"
   "intel-opencl-icd"


### PR DESCRIPTION
As title says, simply appending `23.04` in the `ubuntu_version_list`. It's now the recommended Ubuntu version to use by Intel see [here](https://dgpu-docs.intel.com/driver/client/overview.html).